### PR TITLE
remove steemit's rpc

### DIFF
--- a/js/libs/rpcs.js
+++ b/js/libs/rpcs.js
@@ -1,7 +1,7 @@
 class Rpcs {
   constructor() {
     console.log("build");
-    this.currentRpc = "https://api.steemit.com/";
+    this.currentRpc = "https://api.hive.blog/";
     this.awaitRollback = false;
     this.DEFAULT_RPC_API = "https://api.steemkeychain.com/hive/rpc";
     this.list = this.initList();


### PR DESCRIPTION
api.steemit.com might cause users to accidentally broadcast on the steem network.