### PR TITLE
Encrypt transfer's memo when pushed via requestBroadcast

### DIFF
--- a/js/background/ops/broadcast.js
+++ b/js/background/ops/broadcast.js
@@ -3,6 +3,23 @@ const broadcastData = data => {
     const operations = data.operations;
     const broadcastKeys = {};
     broadcastKeys[data.typeWif] = key;
+
+    // check if operations contains any transfer wich requires memo encryption
+    for(op of operations) {
+      if(op[0]=="transfer") {
+        const memo = op[1].memo
+        if (memo && memo.length > 0 && memo[0] == "#") {
+          try {
+            const receiver = await steem.api.getAccountsAsync([op[1].to]);
+            const memoReceiver = receiver[0].memo_key;
+            op[1].memo = window.encodeMemo(ac.getKey("memo"), memoReceiver, memo);
+          } catch (e) {
+            console.log(e);
+          }
+        }
+      }
+    }
+
     steem.broadcast.send(
       {
         operations,


### PR DESCRIPTION
Memos are not encrypted when sent to the blockchain via requestBroadcast.
TODO - Implement error management in try/catch to avoid memo being sent in clear if encryption fails