### PR TITLE
Implement Hive Unified Wallet Protocol registration

### DIFF
--- a/public/hive_keychain.js
+++ b/public/hive_keychain.js
@@ -1125,3 +1125,26 @@ window.addEventListener(
   },
   false,
 );
+
+// ---------------------------------------------------------------------------
+// Hive Unified Wallet Protocol
+// Registers on the shared window.hive namespace so dApps can use a single
+// API (window.hive) regardless of which wallet extension is installed.
+// See: https://ecency.github.io/browser-extension/hive-wallet-discovery.html
+// ---------------------------------------------------------------------------
+
+// Identity flag
+hive_keychain.isKeychain = true;
+
+// Register on shared namespace
+if (!window.hive) {
+  window.hive = hive_keychain;
+}
+if (!window.hive.providers) {
+  window.hive.providers = [];
+}
+window.hive.providers.push({
+  name: 'Hive Keychain',
+  rdns: 'com.hivekeychain',
+  provider: hive_keychain,
+});

--- a/public/hive_keychain.js
+++ b/public/hive_keychain.js
@@ -1088,6 +1088,7 @@ var hive_keychain = {
     data = Object.assign(
       {
         request_id: this.current_id,
+        extension_id: 'keychain',
       },
       data,
     );

--- a/src/content-scripts/web-interface/index.ts
+++ b/src/content-scripts/web-interface/index.ts
@@ -47,8 +47,14 @@ type KeychainRequestWrapper = {
   detail: KeychainRequest;
 };
 document.addEventListener('swRequest_hive', (request: object) => {
+  const detail = (request as KeychainRequestWrapper).detail;
+  // When extension_id is present, only process events meant for Keychain.
+  // Events without extension_id are legacy and processed for backward compatibility.
+  const extId = (detail as any).extension_id;
+  if (extId && extId !== 'keychain') return;
+  
   const prevReq = req;
-  req = (request as KeychainRequestWrapper).detail;
+  req = detail;
   const validation = validateRequest(req);
   const { error, value } = validation;
   if (!error) {


### PR DESCRIPTION
Added Hive Unified Wallet Protocol registration to enable dApps to use a single API across wallet extensions.