### PR TITLE
fix(keychainify): track checked anchors in WeakSet instead of DOM class

### DIFF
--- a/src/__tests__/content-scripts/keychainify/index.test.ts
+++ b/src/__tests__/content-scripts/keychainify/index.test.ts
@@ -1,0 +1,67 @@
+import contentScript from 'src/content-scripts/keychainify/index';
+
+describe('index.ts (keychainify content script) tests:\n', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  describe('checkAnchors cases:\n', () => {
+    it('Must not write a keychainify-checked class on the anchor (regression: hydration mismatch)', async () => {
+      document.body.innerHTML = '<a href="hive://sign/op/xyz"></a>';
+      const anchor = document.querySelector('a') as HTMLAnchorElement;
+
+      await contentScript.process.checkAnchors(false);
+
+      expect(anchor.classList.contains('keychainify-checked')).toBe(false);
+      expect(anchor.className).toBe('');
+    });
+
+    it('Must attach a click listener only once for a supported hive-uri anchor across repeated calls', async () => {
+      document.body.innerHTML = '<a href="hive://sign/op/xyz"></a>';
+      const anchor = document.querySelector('a') as HTMLAnchorElement;
+      const sAddEventListener = jest.spyOn(anchor, 'addEventListener');
+
+      await contentScript.process.checkAnchors(false);
+      await contentScript.process.checkAnchors(false);
+
+      expect(sAddEventListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('Must not attach a click listener for a hivesigner url when keychainify is disabled', async () => {
+      document.body.innerHTML =
+        '<a href="https://hivesigner.com/sign/transfer?to=bob&amount=1%20HIVE"></a>';
+      const anchor = document.querySelector('a') as HTMLAnchorElement;
+      const sAddEventListener = jest.spyOn(anchor, 'addEventListener');
+
+      await contentScript.process.checkAnchors(false);
+
+      expect(sAddEventListener).not.toHaveBeenCalled();
+    });
+
+    it('Must attach a click listener for a hivesigner url when keychainify is enabled', async () => {
+      document.body.innerHTML =
+        '<a href="https://hivesigner.com/sign/transfer?to=bob&amount=1%20HIVE"></a>';
+      const anchor = document.querySelector('a') as HTMLAnchorElement;
+      const sAddEventListener = jest.spyOn(anchor, 'addEventListener');
+
+      await contentScript.process.checkAnchors(true);
+
+      expect(sAddEventListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function),
+      );
+    });
+
+    it('Must not attach a click listener for an unsupported url', async () => {
+      document.body.innerHTML = '<a href="https://example.com/page"></a>';
+      const anchor = document.querySelector('a') as HTMLAnchorElement;
+      const sAddEventListener = jest.spyOn(anchor, 'addEventListener');
+
+      await contentScript.process.checkAnchors(true);
+
+      expect(sAddEventListener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/content-scripts/keychainify/index.ts
+++ b/src/content-scripts/keychainify/index.ts
@@ -20,6 +20,7 @@ type Process = {
     characterData: boolean;
   };
   observerTimer?: number;
+  checkedAnchors: WeakSet<HTMLAnchorElement>;
   initObserver: () => void;
   checkAnchors: (isKeychainifyEnabled: boolean) => void;
 };
@@ -35,6 +36,7 @@ let contentScript: Props = {
   process: {
     initialized: false,
     observer: null,
+    checkedAnchors: new WeakSet(),
     observerConfig: {
       attributes: false,
       childList: true,
@@ -80,15 +82,14 @@ let contentScript: Props = {
      * Verify all anchors to find HiveSigner links
      */
     checkAnchors: async function (isKeychainifyEnabled: boolean) {
-      let anchors: NodeListOf<HTMLAnchorElement> = document.querySelectorAll(
-        'a[href]:not(.keychainify-checked)',
-      );
+      let anchors: NodeListOf<HTMLAnchorElement> =
+        document.querySelectorAll('a[href]');
 
       for (let i = 0; i < anchors.length; i++) {
         let anchor = anchors[i];
         if (
           anchor.href &&
-          !anchor.classList.contains('keychainify-checked') // That was not checked before
+          !contentScript.process.checkedAnchors.has(anchor) // That was not checked before
         ) {
           /**
            * When keychainify is enabled, both hivesigner and hive-uri will be supported. Otherwise only hive-uri.
@@ -111,7 +112,7 @@ let contentScript: Props = {
           }
         }
 
-        anchor.classList.add('keychainify-checked');
+        contentScript.process.checkedAnchors.add(anchor);
       }
     },
 

--- a/src/content-scripts/keychainify/index.ts
+++ b/src/content-scripts/keychainify/index.ts
@@ -127,3 +127,5 @@ let contentScript: Props = {
 };
 
 contentScript.init();
+
+export default contentScript;


### PR DESCRIPTION
## Summary
- `checkAnchors()` wrote a `keychainify-checked` class onto every anchor in the live DOM, which could mutate the tree before React hydration ran and trigger hydration mismatches on React/Next.js sites.
- Replaced the DOM class marker with an in-memory `WeakSet<HTMLAnchorElement>` for dedup tracking — same behavior, no DOM writes.

## Test plan
- [x] `keychainify.test.ts` passes (2/2)
- [ ] Manual check on a React/Next.js site with hivesigner links: no hydration warning, click-intercept still works